### PR TITLE
Replace \{_} with _ during bib compilation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Build LaTeX
+on: [ push ]
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Git Repo
+        uses: actions/checkout@v2
+      - name: Compile LaTeX document
+        uses: dante-ev/latex-action@master
+        with:
+          root_file: master.tex
+      - name: Upload LaTeX Artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: master.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Mac
 .DS_Store
+
+# IntelliJ
+.idea/

--- a/bibliography/bibliography.bib
+++ b/bibliography/bibliography.bib
@@ -381,5 +381,15 @@ url = {http://faculty.winthrop.edu/domanm/csci411/Handouts/NIST.pdf},
 year = {2011}
 }
 
+@misc{W3SchoolUnderscore,
+    author = {W3},
+    keywords = {html,w3},
+    pages = {1},
+    title = {{HTML Semantic Elements}},
+    url = {https://www.w3schools.com/html/html5{\_}semantic{\_}elements.asp},
+    urldate = {2020-11-28},
+    year = {2020}
+}
+
 
 @Comment{jabref-meta: databaseType:biblatex;}

--- a/cheat_sheet.tex
+++ b/cheat_sheet.tex
@@ -83,6 +83,7 @@ Hier wird nur eine beispielhafte Variante gezeigt!
         \item 'Direktes Zitate'\footnote{\cite[S. 114ff.]{Mayring2002}}
         \item Indirektes Zitate\footnote{Vgl. \cite[S. 114ff.]{Mayring2002}}
         \item Sekundäres indirektes Zitat\footnote{Vgl. \cite[S. 114ff.]{Mayring2002} nach \cite{Endres}}
+        \item Einzelnes sekundäres Zitat\footcite[Vgl.][S.1]{W3SchoolUnderscore}
     \end{itemize}
 
 \section{Einfügen von Referenzen}\label{section:referenzen}

--- a/template/_dhbw_praeambel.tex
+++ b/template/_dhbw_praeambel.tex
@@ -101,6 +101,26 @@
 
 \usepackage{scrhack}             % stellt Kompatibilität zw. KOMA-Script
                                  % (scrreprt) und anderen Paketen her
+
+%% Replaces \{_} url codes in the .bib files to ensure correct underscore usage inside urls
+\DeclareSourcemap{
+    \maps[datatype=bibtex]{
+        \map{
+            \step[
+                fieldsource=url,
+                match={\\\{_\}},
+                replace={_}
+            ]
+        }
+        \map{
+            \step[
+                fieldsource=url,
+                match={\{\\_\}},
+                replace={_}
+            ]
+        }
+    }
+}
                                  
 % Anpassung der Abstände bei Kapitelüberschriften
 % (betrifft auch Inhalts-, Abbildungs- und Tabellenverzeichnis)


### PR DESCRIPTION
As a lot of tools, such as Mendeley, export the sources maintained by
them using \{_} to escape the underscore in URLs most of them were not
clickable in the source reference.

To fight this, the latex template now registers a source map which maps
the \{_} escape string back to the original _ during bibtex compilation.